### PR TITLE
Docs/shorten birth example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.8'
           - '1.9'
           - '^1.10.0-0'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
     steps:

--- a/docs/src/constant_birth.jl
+++ b/docs/src/constant_birth.jl
@@ -123,12 +123,8 @@ function multiple_runs(trial_cnt = 20, max_step = 1000)
      std(trials) / single_expected)
 end
 
-multiple_runs(20, 100)
+multiple_runs(5, 100)
 
 #-
 
-multiple_runs(20, 1000)
-
-#-
-
-multiple_runs(20, 10000)
+multiple_runs(5, 200)


### PR DESCRIPTION
I think package registration is failing b/c docs take too long to build. Just a guess because the jobs are killed. So I'm shortening the longest part.

This also changes the CI to include Julia 1.8 and only run on Ubuntu, not Mac or Windows.