### PR TITLE
changing the uuid so it is different from Fleck's uuid

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "CompetingClocks"
-uuid = "5bb9b785-358c-4fee-af0f-b94a146244a8"
+uuid = "44912038-2626-4ae6-ad06-e3169b445101"
 authors = [
     "Andrew Dolgert <andrew@dolgert.com>",
     "Sean L. Wu <slwood@gmail.com>"


### PR DESCRIPTION
One of the registration errors was about "consistency," and I changed the package name, so maybe it was seeing that Fleck had the same uuid as CompetingClocks. This version generates a new uuid for CompetingClocks.