### PR TITLE
Feature/just likelihood

### DIFF
--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -6,6 +6,10 @@ CurrentModule = CompetingClocks
 
 These are methods which are defined for any samplers subtyping `<:SSA`, the abstract sampler type.
 
+```@docs
+SamplingContext
+```
+
 ## Use a Sampler
 
 ```@docs

--- a/src/context.jl
+++ b/src/context.jl
@@ -46,23 +46,20 @@ end
 
 
 function enable!(ctx::SamplingContext{K,T}, clock::K, dist, te::T, when::T) where {K,T}
-    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
-
     enable!(ctx.sampler, clock, dist, te, when, ctx.rng)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     ctx.recording !== nothing && record_enable!(ctx.recording, clock, ctx.rng)
-    ctx.tracking !== nothing && track_enable!(ctx.tracking, clock, dist, te, when)
+    ctx.debug !== nothing && track_enable!(ctx.debug, clock, dist, te, when)
 end
 
 
 function disable!(ctx::SamplingContext{K,T}, clock::K, when::T) where {K,T}
-    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
     disable!(ctx.sampler, clock, when)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     ctx.recording !== nothing && record_enable!(ctx.recording, clock, ctx.rng)
-    ctx.tracking !== nothing && track_enable!(ctx.tracking, clock, dist, te, when)
+    ctx.debug !== nothing && track_enable!(ctx.debug, clock, dist, te, when)
 end
 
 
@@ -72,34 +69,28 @@ end
 
 
 function fire!(ctx::SamplingContext{K,T}, clock::K, dist, te::T, when::T) where {K,T}
-    ctx.likelihood !== nothing && likelihood_fire!(ctx.likelihood, clock, dist, te, when)
-
     fire!(ctx.sampler, clock, dist, te, when, ctx.rng)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     ctx.recording !== nothing && record_fire!(ctx.recording, clock, ctx.rng)
-    ctx.tracking !== nothing && track_fire!(ctx.tracking, clock, dist, te, when)
+    ctx.debug !== nothing && track_fire!(ctx.debug, clock, dist, te, when)
 end
 
 function reset!(ctx::SamplingContext{K,T}) where {K,T}
-    # Core sampler logic first
-    ctx.likelihood !== nothing && likelihood_reset!(ctx.likelihood, clock, dist, te, when)
     reset!(ctx.sampler)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     ctx.recording !== nothing && record_enable!(ctx.recording, clock, ctx.rng)
-    ctx.tracking !== nothing && track_enable!(ctx.tracking, clock, dist, te, when)
+    ctx.debug !== nothing && track_enable!(ctx.debug, clock, dist, te, when)
 end
 
 
 function Base.copy!(src::SamplingContext{K,T}, dst::SamplingContext{K,T}) where {K,T}
-    # Core sampler logic first
     copy!(src.sampler, dst.sampler)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     src.recording !== nothing && record_copy!(src.recording, clock, src.rng)
     src.tracking !== nothing && track_copy!(src.tracking, clock, dist, te, when)
-    src.likelihood !== nothing && likelihood_copy!(src.likelihood, clock, dist, te, when)
 end
 
 
@@ -109,8 +100,7 @@ function Base.getindex(ctx::SamplingContext{K}, clock::K) where {K}
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     ctx.recording !== nothing && record_enable!(ctx.recording, clock, ctx.rng)
-    ctx.tracking !== nothing && track_enable!(ctx.tracking, clock, dist, te, when)
-    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
+    ctx.debug !== nothing && track_enable!(ctx.debug, clock, dist, te, when)
 end
 
 
@@ -120,8 +110,7 @@ function Base.keys(ctx::SamplingContext)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     ctx.recording !== nothing && record_keys(ctx.recording, clock, ctx.rng)
-    ctx.tracking !== nothing && track_keys(ctx.tracking, clock, dist, te, when)
-    ctx.likelihood !== nothing && likelihood_keys(ctx.likelihood, clock, dist, te, when)
+    ctx.debug !== nothing && track_keys(ctx.debug, clock, dist, te, when)
 end
 
 
@@ -131,8 +120,7 @@ function Base.length(ctx::SamplingContext)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     ctx.recording !== nothing && record_enable!(ctx.recording, clock, ctx.rng)
-    ctx.tracking !== nothing && track_enable!(ctx.tracking, clock, dist, te, when)
-    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
+    ctx.debug !== nothing && track_enable!(ctx.debug, clock, dist, te, when)
 end
 
 
@@ -142,8 +130,7 @@ function Base.haskey(ctx::SamplingContext{K}, clock::K) where {K}
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     ctx.recording !== nothing && record_enable!(ctx.recording, clock, ctx.rng)
-    ctx.tracking !== nothing && track_enable!(ctx.tracking, clock, dist, te, when)
-    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
+    ctx.debug !== nothing && track_enable!(ctx.debug, clock, dist, te, when)
 end
 
 
@@ -154,12 +141,10 @@ Base.keytype(ctx::SamplingContext{K}) where {K} = K
 timetype(ctx::SamplingContext{K,T}) where {K,T} = T
 
 function steploglikelihood(dc::SamplingContext, now, when, which)
-    ctx.likelihood !== nothing && return steploglikelihood(ctx.likelihood, now, when, which)
     return steploglikelihood(ctx.sampler, now, when, which)
 end
 
 
 function trajectoryloglikelihood(dc::SamplingContext)
-    ctx.likelihood !== nothing && return trajectoryloglikelihood(ctx.likelihood)
     return trajectoryloglikelihood(ctx.sampler)
 end

--- a/src/context.jl
+++ b/src/context.jl
@@ -1,55 +1,94 @@
+"""
+The SamplingContext is responsible for doing a perfect forwarding to multiple
+components that implement the desired features in a sampler.
 
-struct SamplingContext{K,T,Sampler<:SSA{K,T},RNG,Rec,Trk,Lk}
+It uses a Context pattern where each type parameter is either present or
+Nothing, and the compiler knows to optimize-away the Nothing.
+We keep the internal logic simple. If something is present, call it.
+
+ - memory
+ - delayed transitions
+ - hierarchical samplers
+"""
+struct SamplingContext{K,T,Sampler<:SSA{K,T},RNG,Rec,Dbg}
     sampler::Sampler # The actual sampler
     rng::RNG
     recording::Rec  # Union{Nothing, RecordingState{K,RNG}}
-    tracking::Trk   # Union{Nothing, TrackingState{K,T}}
-    likelihood::Lk  # Union{Nothing, LikelihoodState{K,T}}
+    debug::Dbg      # Union{Nothing, TrackingState{K,T}}
     split_weight::Float64
 end
 
 
+step_likelihood_api(::Type) = false
+track_likelihood_api(::Type) = false
+enabled_api(::Type) = false
+
+#=
+M = maybe soon. X = yes. ' ' = no.
+FTF-S is a first-to-fire version that stores more information.
+
+        STEP TRACK ENABLED
+NR      M    M     X
+Direct  X    M     X
+FR      X          X
+FR-T    X    X     X
+FTF
+FTF-S   X          X
+FTF-ST  X    X     X
+Petri   X          X
+Petri-T X    X     X
+=#
+
+function make_sampler(
+    ;
+)
+end
+
+
 function enable!(ctx::SamplingContext{K,T}, clock::K, dist, te::T, when::T) where {K,T}
-    # Core sampler logic first
+    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
+
     enable!(ctx.sampler, clock, dist, te, when, ctx.rng)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     ctx.recording !== nothing && record_enable!(ctx.recording, clock, ctx.rng)
     ctx.tracking !== nothing && track_enable!(ctx.tracking, clock, dist, te, when)
-    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
 end
 
 
 function disable!(ctx::SamplingContext{K,T}, clock::K, when::T) where {K,T}
-    # Core sampler logic first
+    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
     disable!(ctx.sampler, clock, when)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     ctx.recording !== nothing && record_enable!(ctx.recording, clock, ctx.rng)
     ctx.tracking !== nothing && track_enable!(ctx.tracking, clock, dist, te, when)
-    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
 end
 
 
 function next(ctx::SamplingContext{K,T}, when::T) where {K,T}
-    # Core sampler logic first
     next(ctx.sampler, when, ctx.rng)
-
-    # Feature hooks (compiler eliminates branches when types are Nothing)
-    ctx.recording !== nothing && record_enable!(ctx.recording, clock, ctx.rng)
-    ctx.tracking !== nothing && track_enable!(ctx.tracking, clock, dist, te, when)
-    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
 end
 
 
+function fire!(ctx::SamplingContext{K,T}, clock::K, dist, te::T, when::T) where {K,T}
+    ctx.likelihood !== nothing && likelihood_fire!(ctx.likelihood, clock, dist, te, when)
+
+    fire!(ctx.sampler, clock, dist, te, when, ctx.rng)
+
+    # Feature hooks (compiler eliminates branches when types are Nothing)
+    ctx.recording !== nothing && record_fire!(ctx.recording, clock, ctx.rng)
+    ctx.tracking !== nothing && track_fire!(ctx.tracking, clock, dist, te, when)
+end
+
 function reset!(ctx::SamplingContext{K,T}) where {K,T}
     # Core sampler logic first
+    ctx.likelihood !== nothing && likelihood_reset!(ctx.likelihood, clock, dist, te, when)
     reset!(ctx.sampler)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
     ctx.recording !== nothing && record_enable!(ctx.recording, clock, ctx.rng)
     ctx.tracking !== nothing && track_enable!(ctx.tracking, clock, dist, te, when)
-    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
 end
 
 
@@ -58,9 +97,9 @@ function Base.copy!(src::SamplingContext{K,T}, dst::SamplingContext{K,T}) where 
     copy!(src.sampler, dst.sampler)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
-    src.recording !== nothing && record_enable!(src.recording, clock, src.rng)
-    src.tracking !== nothing && track_enable!(src.tracking, clock, dist, te, when)
-    src.likelihood !== nothing && likelihood_enable!(src.likelihood, clock, dist, te, when)
+    src.recording !== nothing && record_copy!(src.recording, clock, src.rng)
+    src.tracking !== nothing && track_copy!(src.tracking, clock, dist, te, when)
+    src.likelihood !== nothing && likelihood_copy!(src.likelihood, clock, dist, te, when)
 end
 
 
@@ -80,9 +119,9 @@ function Base.keys(ctx::SamplingContext)
     keys(ctx.sampler, clock)
 
     # Feature hooks (compiler eliminates branches when types are Nothing)
-    ctx.recording !== nothing && record_enable!(ctx.recording, clock, ctx.rng)
-    ctx.tracking !== nothing && track_enable!(ctx.tracking, clock, dist, te, when)
-    ctx.likelihood !== nothing && likelihood_enable!(ctx.likelihood, clock, dist, te, when)
+    ctx.recording !== nothing && record_keys(ctx.recording, clock, ctx.rng)
+    ctx.tracking !== nothing && track_keys(ctx.tracking, clock, dist, te, when)
+    ctx.likelihood !== nothing && likelihood_keys(ctx.likelihood, clock, dist, te, when)
 end
 
 
@@ -115,4 +154,12 @@ Base.keytype(ctx::SamplingContext{K}) where {K} = K
 timetype(ctx::SamplingContext{K,T}) where {K,T} = T
 
 function steploglikelihood(dc::SamplingContext, now, when, which)
+    ctx.likelihood !== nothing && return steploglikelihood(ctx.likelihood, now, when, which)
+    return steploglikelihood(ctx.sampler, now, when, which)
+end
+
+
+function trajectoryloglikelihood(dc::SamplingContext)
+    ctx.likelihood !== nothing && return trajectoryloglikelihood(ctx.likelihood)
+    return trajectoryloglikelihood(ctx.sampler)
 end

--- a/src/sample/firstreaction.jl
+++ b/src/sample/firstreaction.jl
@@ -17,70 +17,26 @@ One interesting property of this sampler is that you can call `next()`
 multiple times in order to get a distribution of next firing clocks and their
 times to fire.
 """
-struct FirstReaction{K,T} <: SSA{K,T}
-	# This other class already stores the current set of distributions, so use it.
-    core_matrix::TrackWatcher{K}
-	FirstReaction{K,T}() where {K,T <: ContinuousTime} = new(TrackWatcher{K,T}())
+struct FirstReaction{K,T} <: EnabledWatcher{K,T}
+    enabled::Dict{K,EnablingEntry{K,T}}
+    FirstReaction{K,T}() where {K,T<:ContinuousTime} = new(Dict{K,EnablingEntry{K,T}}())
 end
 
 
-reset!(fr::FirstReaction) = reset!(fr.core_matrix)
-Base.copy!(dst::FirstReaction{K,T}, src::FirstReaction{K,T}) where {K,T} = (copy!(dst.core_matrix, src.core_matrix); dst)
-
-
-function enable!(fr::FirstReaction{K,T}, clock::K, distribution::UnivariateDistribution,
-		te::T, when::T, rng::AbstractRNG) where {K,T}
-
-	enable!(fr.core_matrix, clock, distribution, te, when, rng)
-end
-
-
-function disable!(fr::FirstReaction{K,T}, clock::K, when::T) where {K,T}
-	disable!(fr.core_matrix, clock, when)
+function _sample_time(entry::EnablingEntry, when::T, rng) where {T}
+    dist = entry.te < when ?
+           truncated(entry.distribution, when - entry.te, typemax(T)) :
+           entry.distribution
+    return entry.te + rand(rng, dist)
 end
 
 
 function next(fr::FirstReaction{K,T}, when::T, rng::AbstractRNG) where {K,T}
-	soonest_clock::Union{Nothing,K} = nothing
-	soonest_time = typemax(T)
-
-    for entry::EnablingEntry{K,T} in fr.core_matrix
-		if entry.te < when
-			relative_dist = truncated(entry.distribution, when - entry.te, typemax(T))
-			putative_time = entry.te + rand(rng, relative_dist)
-		else
-			putative_time = entry.te + rand(rng, entry.distribution)
-		end
-		if putative_time < soonest_time
-			soonest_clock = entry.clock
-			soonest_time = putative_time
-		end
-	end
-	return (soonest_time, soonest_clock)
+    isempty(fr.enabled) && return (typemax(T), nothing)
+    return minimum(
+        ((_sample_time(entry, when, rng), entry.clock) for entry in values(fr.enabled))
+    )
 end
-
-"""
-	getindex(sampler::FirstReaction{K,T}, clock::K)
-
-For the `FirstReaction` sampler, returns the distribution object associated to the clock.
-"""
-function Base.getindex(fr::FirstReaction{K,T}, clock::K) where {K,T}
-    if haskey(fr.core_matrix.enabled, clock)
-        return getfield(fr.core_matrix.enabled[clock], :distribution)
-    else
-        throw(KeyError(clock))
-    end
-end
-
-function Base.keys(fr::FirstReaction)
-    return collect(keys(fr.core_matrix.enabled))
-end
-
-function Base.length(fr::FirstReaction)
-    return length(fr.core_matrix.enabled)
-end
-
-Base.haskey(fr::FirstReaction, clock) = isenabled(fr.core_matrix, clock)
 
 
 """
@@ -89,62 +45,62 @@ all of the things and uses Julia's logger to communicate them. It samples
 using the first reaction algorithm.
 """
 mutable struct ChatReaction{K,T}
-	# This other class already stores the current set of distributions, so use it.
-    core_matrix::TrackWatcher{K}
-	step_cnt::Int64
-	enables::Set{K}
-	disables::Set{K}
-	ChatReaction{K,T}() where {K,T<:ContinuousTime} = new(TrackWatcher{K,T}(), 0, Set{K}(), Set{K}())
+    # This other class already stores the current set of distributions, so use it.
+    enabled::TrackWatcher{K}
+    step_cnt::Int64
+    enables::Set{K}
+    disables::Set{K}
+    ChatReaction{K,T}() where {K,T<:ContinuousTime} = new(TrackWatcher{K,T}(), 0, Set{K}(), Set{K}())
 end
 
 
 function enable!(fr::ChatReaction{K,T}, clock::K, distribution::UnivariateDistribution,
-		te::T, when::T, rng::AbstractRNG) where {K,T}
+    te::T, when::T, rng::AbstractRNG) where {K,T}
 
-	if clock ∈ keys(fr.core_matrix.enabled)
-		@warn "Re-enabling transition $clock without disabling first"
-	end
-	enable!(fr.core_matrix, clock, distribution, te, when, rng)
-	push!(fr.enables, clock)
+    if clock ∈ keys(fr.enabled.enabled)
+        @warn "Re-enabling transition $clock without disabling first"
+    end
+    enable!(fr.enabled, clock, distribution, te, when, rng)
+    push!(fr.enables, clock)
 end
 
 
 function disable!(fr::ChatReaction{K,T}, clock::K, when::T) where {K,T}
-	if clock ∉ fr.enables
-		@warn "Disabling a clock that was never enabled: $(clock)."
-	end
-	if clock ∉ keys(fr.core_matrix.enabled)
-		@warn "Disabling clock $(clock) that wasn't currently enabled"
-	end
-	disable!(fr.core_matrix, clock, when)
-	push!(fr.disables, clock)
+    if clock ∉ fr.enables
+        @warn "Disabling a clock that was never enabled: $(clock)."
+    end
+    if clock ∉ keys(fr.enabled.enabled)
+        @warn "Disabling clock $(clock) that wasn't currently enabled"
+    end
+    disable!(fr.enabled, clock, when)
+    push!(fr.disables, clock)
 end
 
 
 function next(fr::ChatReaction{K,T}, when::T, rng) where {K,T}
-	soonest_clock = nothing
-	soonest_time = typemax(T)
+    soonest_clock = nothing
+    soonest_time = typemax(T)
 
-	if length(fr.enables) == 0
-		@warn "No transitions have ever been enabled. Sampler may not be initialized."
-	end
+    if length(fr.enables) == 0
+        @warn "No transitions have ever been enabled. Sampler may not be initialized."
+    end
 
-    for entry::EnablingEntry{K,T} in fr.core_matrix
-		if entry.te < when
-			relative_dist = truncated(entry.distribution, when - entry.te, typemax(T))
-			putative_time = entry.te + rand(rng, relative_dist)
-		else
-			putative_time = entry.te + rand(rng, entry.distribution)
-		end
-		if putative_time < soonest_time
-			soonest_clock = entry.clock
-			soonest_time = putative_time
-		end
-	end
-	fr.step_cnt += 1
-	@debug "Step $(fr.step_cnt) time $(soonest_time) fire $(soonest_clock)"
-	return (soonest_time, soonest_clock)
+    for entry::EnablingEntry{K,T} in fr.enabled
+        if entry.te < when
+            relative_dist = truncated(entry.distribution, when - entry.te, typemax(T))
+            putative_time = entry.te + rand(rng, relative_dist)
+        else
+            putative_time = entry.te + rand(rng, entry.distribution)
+        end
+        if putative_time < soonest_time
+            soonest_clock = entry.clock
+            soonest_time = putative_time
+        end
+    end
+    fr.step_cnt += 1
+    @debug "Step $(fr.step_cnt) time $(soonest_time) fire $(soonest_clock)"
+    return (soonest_time, soonest_clock)
 end
 
 
-Base.haskey(fr::ChatReaction, clock) = isenabled(fr.core_matrix, clock)
+Base.haskey(fr::ChatReaction, clock) = isenabled(fr.enabled, clock)

--- a/src/sample/petri.jl
+++ b/src/sample/petri.jl
@@ -8,50 +8,19 @@ This sampler adopts the Petri net rule for which clock fires next: it's randomly
 chosen among all enabled events. The returned time is always the previous time
 plus one.
 """
-mutable struct Petri{K,T} <: SSA{K,T}
-    watcher::TrackWatcher{K,T}
+mutable struct Petri{K,T} <: EnabledWatcher{K,T}
+    enabled::Dict{K,EnablingEntry{K,T}}
     time_duration::Float64
-    Petri{K,T}() where {K,T} = new(TrackWatcher{K,T}(), 1.0)
+    Petri{K,T}(dt=1.0) where {K,T} = new(Dict{K,EnablingEntry{K,T}}(), dt)
 end
 
-reset!(propagator::Petri{K,T}) where {K,T} = reset!(propagator.watcher)
+function Base.copy!(dst::Petri, src::Petri)
+    copy!(dst.enabled, src.enabled)
+    dst.time_duration = src.time_duration
+    return dst
+end
 
-Base.copy!(dst::Petri{K,T}, src::Petri{K,T}) where {K,T} = copy!(dst.watcher, src.watcher)
-
-# Finds the next one without removing it from the queue.
 function next(propagator::Petri{K,T}, when::T, rng::AbstractRNG) where {K,T}
-    chosen = rand(rng, keys(propagator.watcher.enabled))
+    chosen = rand(rng, keys(propagator.enabled))
     (when + propagator.time_duration, chosen)
 end
-
-
-function enable!(
-    propagator::Petri{K,T}, clock::K, distribution::UnivariateDistribution,
-    te::T, when::T, rng::AbstractRNG) where {K,T}
-    return enable!(propagator.watcher, clock, distribution, te, when, rng)
-end
-
-
-function disable!(propagator::Petri{K,T}, clock::K, when::T) where {K,T}
-    return disable!(propagator.watcher, clock, when)
-end
-
-"""
-    getindex(sampler::Petri{K,T}, clock::K)
-
-For the `Petri` sampler, returns the `EnablingEntry` time associated to the clock.
-"""
-function Base.getindex(propagator::Petri{K,T}, clock::K) where {K,T}
-    return propagator.watcher.enabled[clock]
-end
-
-function Base.keys(propagator::Petri)
-    return collect(keys(propagator.watcher.enabled))
-end
-
-function Base.length(propagator::Petri)
-    return length(propagator.watcher)
-end
-
-
-Base.haskey(propagator::Petri, clock) = isenabled(propagator.watcher, clock)

--- a/src/trace/debug.jl
+++ b/src/trace/debug.jl
@@ -1,5 +1,6 @@
 using Base
 using Logging
+using Random: AbstractRNG
 using Distributions: UnivariateDistribution
 
 """
@@ -41,13 +42,13 @@ function Base.copy!(dst::DebugWatcher{K,T}, src::DebugWatcher{K,T}) where {K,T}
     copy!(dst.disabled, src.disabled)
 end
 
-function enable!(ts::DebugWatcher{K,T}, clock::K, dist::UnivariateDistribution, te, when, rng) where {K,T}
+function enable!(ts::DebugWatcher{K,T}, clock::K, dist::UnivariateDistribution, te::T, when::T, rng::AbstractRNG) where {K,T}
     ts.log && @debug "enable! $(clock) $(dist) $(te) $(when)"
     push!(ts.enabled, EnablingEntry(clock, dist, te, when))
 end
 
 
-function disable!(ts::DebugWatcher{K,T}, clock::K, when) where {K,T}
+function disable!(ts::DebugWatcher{K,T}, clock::K, when::T) where {K,T}
     ts.log && @debug "disable! $(clock) $(when)"
     push!(ts.disabled, DisablingEntry(clock, when))
 end

--- a/src/trace/debug.jl
+++ b/src/trace/debug.jl
@@ -1,4 +1,5 @@
 using Base
+using Logging
 using Distributions: UnivariateDistribution
 
 """
@@ -21,22 +22,32 @@ watcher.enabled[1].when)
 mutable struct DebugWatcher{K,T}
     enabled::Vector{EnablingEntry{K,T}}
     disabled::Vector{DisablingEntry{K,T}}
-    DebugWatcher{K,T}() where {K,T}=new(Vector{EnablingEntry{K,T}}(), Vector{DisablingEntry{K,T}}())
+    log::Bool
+    DebugWatcher{K,T}(; log=true) where {K,T} =
+        new(Vector{EnablingEntry{K,T}}(), Vector{DisablingEntry{K,T}}(), log)
 end
 
 
-reset!(ts::DebugWatcher) = (empty!(ts.enabled); empty!(ts.disabled); nothing)
+function reset!(ts::DebugWatcher)
+    ts.log && @debug "reset!"
+    empty!(ts.enabled)
+    empty!(ts.disabled)
+    nothing
+end
 
 function Base.copy!(dst::DebugWatcher{K,T}, src::DebugWatcher{K,T}) where {K,T}
+    src.log && @debug "copy!"
     copy!(dst.enabled, src.enabled)
     copy!(dst.disabled, src.disabled)
 end
 
 function enable!(ts::DebugWatcher{K,T}, clock::K, dist::UnivariateDistribution, te, when, rng) where {K,T}
+    ts.log && @debug "enable! $(clock) $(dist) $(te) $(when)"
     push!(ts.enabled, EnablingEntry(clock, dist, te, when))
 end
 
 
 function disable!(ts::DebugWatcher{K,T}, clock::K, when) where {K,T}
+    ts.log && @debug "disable! $(clock) $(when)"
     push!(ts.disabled, DisablingEntry(clock, when))
 end

--- a/src/trace/track.jl
+++ b/src/trace/track.jl
@@ -93,14 +93,6 @@ isenabled(ts::EnabledWatcher{K,T}, clock::K) where {K,T} = haskey(ts.enabled, cl
 isenabled(ts::EnabledWatcher{K,T}, clock) where {K,T} = false
 
 
-"""
-    steploglikelihood(tw::TrackWatcher, now, when_fires, which_fires)
-
-Calculate the log-likelihood of a single step in which the `which_fires`
-transition fires next. `now` is the current time. `when_fires` is the time when
-`which_fires` happens so `when > now`. You have to call this before the transition fires so that
-it is before transitions are enabled and disabled from the previous step.
-"""
 function _steploglikelihood(enabled, t0, t, which_fires)
     # Look for a description of this in docs/notes/distributions.pdf, under log-likelihood.
     @assert t >= t0

--- a/src/trace/track.jl
+++ b/src/trace/track.jl
@@ -43,7 +43,7 @@ end
 """
 mutable struct TrackWatcher{K,T}
     enabled::Dict{K,EnablingEntry{K,T}}
-    TrackWatcher{K,T}() where {K,T}=new(Dict{K,EnablingEntry{K,T}}())
+    TrackWatcher{K,T}() where {K,T} = new(Dict{K,EnablingEntry{K,T}}())
 end
 
 function absolute_enabling(dst::TrackWatcher{K,T}, clock::K) where {K,T}
@@ -134,7 +134,7 @@ function MemorySampler(sampler::Sampler) where {Sampler}
     T = timetype(sampler)
     MemorySampler{Sampler,K,T}(
         sampler, TrackWatcher{K,T}(), zero(T)
-        )
+    )
 end
 
 export MemorySampler
@@ -162,5 +162,3 @@ end
 function Base.getindex(propagator::MemorySampler, clock)
     getindex(propagator.sampler, clock)
 end
-
-

--- a/src/trace/trajectory.jl
+++ b/src/trace/trajectory.jl
@@ -1,5 +1,4 @@
 using Base
-using Distributions: UnivariateDistribution
 
 mutable struct TrajectoryWatcher{K,T} <: EnabledWatcher{K,T}
     enabled::Dict{K,EnablingEntry{K,T}}
@@ -36,7 +35,7 @@ function Base.copy!(dst::TrajectoryWatcher{K,T}, src::TrajectoryWatcher{K,T}) wh
 end
 
 
-function disable!(ts::TrajectoryWatcher{K,T}, clock::K, when) where {K,T}
+function disable!(ts::TrajectoryWatcher{K,T}, clock::K, when::T) where {K,T}
     entry = get(ts.enabled, clock, nothing)
     if entry !== nothing
         if when > entry.te

--- a/test/test_context.jl
+++ b/test/test_context.jl
@@ -9,10 +9,10 @@ import InteractiveUtils: @code_typed
     K = Int64
     T = Float64
     S = FirstToFire{Int64,Float64}
-    SC = CompetingClocks.SamplingContext{K,T,S,Xoshiro,Nothing,Nothing,Nothing}
+    SC = CompetingClocks.SamplingContext{K,T,S,Xoshiro,Nothing,Nothing}
 
     rng = Xoshiro(899987987)
-    sampler = SC(FirstToFire{Int64,Float64}(), rng, nothing, nothing, nothing, 0.0)
+    sampler = SC(FirstToFire{Int64,Float64}(), rng, nothing, nothing, 0.0)
     for (clock_id, propensity) in enumerate([0.3, 0.2, 0.7, 0.001, 0.25])
         enable!(sampler, clock_id, Exponential(propensity), 0.0, 0.0)
     end
@@ -38,8 +38,9 @@ end
     NR = CombinedNextReaction{Int,Float64}
     for SamplerType in [FTF, DC, FR, NR]
         sampler = SamplerType()
-        SC = CompetingClocks.SamplingContext{K,T,SamplerType,Xoshiro,Nothing,Nothing,Nothing}
         rng = Xoshiro(90422342)
+        SC = CompetingClocks.SamplingContext{K,T,SamplerType,Xoshiro,Nothing,Nothing}
+        context = SC(sampler, rng, nothing, nothing, 0.0)
         enabled = Set{Int64}()
         for (clock_id, propensity) in enumerate([0.3, 0.2, 0.7, 0.001, 0.25])
             enable!(sampler, clock_id, Exponential(propensity), 0.0, 0.0, rng)

--- a/test/test_firstreaction.jl
+++ b/test/test_firstreaction.jl
@@ -44,16 +44,15 @@ end
 
     @test length(sampler) == 5
     @test length(keys(sampler)) == 5
-    @test sampler[1] == Dirac(7.9)
+    @test sampler[1].distribution == Dirac(7.9)
 
     @test haskey(sampler, 1)
     @test !haskey(sampler, 1_000)
-    @test !haskey(sampler, "1")
 
     disable!(sampler, 1, 0.0)
 
     @test_throws KeyError sampler[1]
-    @test sampler[2] == Dirac(12.3)
+    @test sampler[2].distribution == Dirac(12.3)
     reset!(sampler)
 end
 
@@ -131,7 +130,7 @@ end
     ks1_test = ExactOneSampleKSTest(samples, dist)
     @test pvalue(ks1_test) < 0.04
     ks2_test = ExactOneSampleKSTest(samples, truncated(dist, later, Inf))
-    @test pvalue(ks2_test; tail = :both) > 0.04
+    @test pvalue(ks2_test; tail=:both) > 0.04
 end
 
 
@@ -156,7 +155,7 @@ end
     @test pvalue(ks1_test) < 0.04
     shifted = [(x - future) for x in samples]
     ks2_test = ExactOneSampleKSTest(shifted, dist)
-    @test pvalue(ks2_test; tail = :both) > 0.04
+    @test pvalue(ks2_test; tail=:both) > 0.04
 end
 
 

--- a/test/test_petri.jl
+++ b/test/test_petri.jl
@@ -15,7 +15,7 @@
     enable!(tw, 7, Exponential(0.001), 5.0, 5.0, rng)
     @test length(tw) == 3 && 7 ∈ keys(tw)
 
-    counts = Dict{Int,Int}(3 => 0, 4 => 0, 7=> 0)
+    counts = Dict{Int,Int}(3 => 0, 4 => 0, 7 => 0)
     for i in 1:1000
         when = 100 * rand(rng)
         time_out, which = next(tw, when, rng)
@@ -50,5 +50,4 @@ end
     @test tw[3].distribution == Exponential(100.0)
     @test haskey(tw, 3)
     @test !haskey(tw, 4)
-    @test !haskey(tw, "wrong type")
 end

--- a/test/test_vas_integrate.jl
+++ b/test/test_vas_integrate.jl
@@ -2,7 +2,7 @@ using SafeTestsets
 using Test
 
 
-@safetestset vas_sample = "VAS samples with direct" begin
+@safetestset vas_sample_direct = "VAS samples with direct" begin
 using Random: MersenneTwister
 using CompetingClocks: DirectCall
 using ..VectorAddition
@@ -27,7 +27,7 @@ using ..SampleVAS: sample_sir
 end
 
 
-@safetestset vas_sample = "VAS samples with first reaction" begin
+@safetestset vas_sample_fr = "VAS samples with first reaction" begin
     using Random: MersenneTwister
     using CompetingClocks: FirstReaction
     using ..VectorAddition
@@ -53,7 +53,7 @@ end
 
 
 
-@safetestset vas_sample = "VAS samples with first to fire" begin
+@safetestset vas_sample_ftf = "VAS samples with first to fire" begin
     using Random: MersenneTwister
     using CompetingClocks: FirstToFire
     using ..VectorAddition


### PR DESCRIPTION
This feature branch adds log-likelihood accumulation capabilities and refactors the watcher/tracking infrastructure:

  Core Changes:
  - Added optional log-likelihood tracking to Direct method and CombinedNR sampler
  - Introduced steploglikelihood as a free method with abstract TrackWatcher base class shared between tracking and trajectory watchers
  - Added log argument to DebugWatcher for debugging likelihood calculations

  Refactoring:
  - Simplified FirstReaction (154 lines → cleaner implementation) and Petri samplers by leveraging improved tracking/trajectory infrastructure
  - Consolidated watcher logic reducing overall codebase by ~11 lines while adding functionality

  Documentation:
  - Minor doc build improvements

  Net impact: 310 insertions, 321 deletions across 14 files.